### PR TITLE
Fix replace gas stations and scheduler stop on fail

### DIFF
--- a/app/src/main/kotlin/botlinera/application/usecases/UpdateGasStations.kt
+++ b/app/src/main/kotlin/botlinera/application/usecases/UpdateGasStations.kt
@@ -17,6 +17,11 @@ class UpdateGasStations(
 
     fun execute() = runCatching {
         val gasStations: List<GasStation> = gasStationsRetriever.apply().getOrThrow()
+
+        if (gasStations.isEmpty()) {
+            LOG.info("Gas stations were not found")
+            return Result.success(Unit)
+        }
         gasStationPersister.replace(gasStations).getOrThrow()
         LOG.info("Gas stations were updated in database")
     }.onFailure {

--- a/app/src/main/kotlin/botlinera/infrastructure/App.kt
+++ b/app/src/main/kotlin/botlinera/infrastructure/App.kt
@@ -15,17 +15,20 @@ import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoDatabase
 import org.litote.kmongo.KMongo
 import org.litote.kmongo.getCollectionOfName
+import java.util.concurrent.TimeUnit.MINUTES
 
+private const val INITIAL_DELAY = 0L
+private const val PERIOD = 30L
 
 fun main() {
     val gasStationPersister = GasStationPersisterMongo(mongoCollection())
 
-    GasStationScheduler().start {
+    GasStationScheduler.start({
         UpdateGasStations(
             GasStationsRetrieverFromSpanishGovernment(URLWrapper()),
             gasStationPersister
         ).execute()
-    }
+    }, INITIAL_DELAY, PERIOD, MINUTES)
     TelegramBot().startPolling()
 }
 

--- a/app/src/main/kotlin/botlinera/infrastructure/adapters/GasStationPersisterMongo.kt
+++ b/app/src/main/kotlin/botlinera/infrastructure/adapters/GasStationPersisterMongo.kt
@@ -56,6 +56,9 @@ class GasStationPersisterMongo(private val collection: MongoCollection<GasStatio
     }
 
     private fun saveGasStations(gasStation: List<GasStation>) {
+        if (gasStation.isEmpty()) {
+            return
+        }
         collection.insertMany(gasStation.map { GasStationDto.from(it) })
     }
 

--- a/app/src/main/kotlin/botlinera/infrastructure/schedulers/GasStationScheduler.kt
+++ b/app/src/main/kotlin/botlinera/infrastructure/schedulers/GasStationScheduler.kt
@@ -1,18 +1,25 @@
 package botlinera.infrastructure.schedulers
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-private const val INITIAL_DELAY = 0L
-private const val PERIOD = 30L
-
 class GasStationScheduler {
-    fun start(job: () -> Unit) {
-        val executorService = Executors.newSingleThreadScheduledExecutor()
-        executorService.scheduleAtFixedRate(
-            {
-                job()
-            }, INITIAL_DELAY, PERIOD, TimeUnit.MINUTES
-        )
+    companion object {
+        private val LOG: Logger = LoggerFactory.getLogger(GasStationScheduler::class.java)
+        fun start(job: () -> Unit, initialDelay: Long, executionInterval: Long, timeUnit: TimeUnit) {
+            val executorService = Executors.newSingleThreadScheduledExecutor()
+            executorService.scheduleAtFixedRate(
+                {
+                    try {
+                        job()
+                    } catch (exception: Exception) {
+                        LOG.error("Error occurred while scheduling job", exception)
+                    }
+                }, initialDelay, executionInterval, timeUnit
+            )
+        }
     }
+
 }

--- a/app/src/test/kotlin/botlinera/application/usecases/UpdateGasStationsShould.kt
+++ b/app/src/test/kotlin/botlinera/application/usecases/UpdateGasStationsShould.kt
@@ -6,10 +6,12 @@ import botlinera.application.exceptions.FailedToUpdateGasStation
 import botlinera.application.ports.GasStationPersister
 import botlinera.application.ports.GasStationsRetriever
 import botlinera.domain.fixtures.valueobjects.GasStationFixtures.Companion.multipleGasStationsWithinAFiveKilometersRadius
+import io.mockk.Called
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.verify
 import io.mockk.verifyOrder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -46,6 +48,17 @@ class UpdateGasStationsShould {
         every { gasStationsRetriever.apply() }.returns(Result.failure(RuntimeException()))
 
         assertFailsWith<FailedToUpdateGasStation> { updateGasStations.execute() }
+    }
+
+    @Test
+    fun `not replace all gas stations when retrieving empty list of gas stations`() {
+        every { gasStationsRetriever.apply() }.returns(Result.success(listOf()))
+
+        updateGasStations.execute()
+
+        verify {
+            gasStationsPersister wasNot Called
+        }
     }
 
 

--- a/app/src/test/kotlin/botlinera/infrastructure/adapters/GasStationPersisterMongoShould.kt
+++ b/app/src/test/kotlin/botlinera/infrastructure/adapters/GasStationPersisterMongoShould.kt
@@ -2,7 +2,9 @@ package botlinera.infrastructure.adapters
 
 import botlinera.application.exceptions.FailedToQueryNearGasStations
 import botlinera.application.exceptions.FailedToReplaceGasStations
+import botlinera.domain.fixtures.valueobjects.GasStationFixtures.Companion.aGasStation
 import botlinera.domain.fixtures.valueobjects.GasStationFixtures.Companion.multipleGasStationsWithinAFiveKilometersRadius
+import botlinera.domain.valueobject.GasStation
 import botlinera.domain.valueobject.GasType.*
 import botlinera.domain.valueobject.MaximumCoordinates
 import botlinera.infrastructure.dtos.GasStationDto
@@ -282,6 +284,28 @@ class GasStationPersisterMongoShould() {
         }
     }
 
+    @Test
+    fun `Replace all gas stations with new ones`() {
+        val gasStation = aGasStation()
+        gasStationPersisterMongo
+            .replace(gasStation)
+
+        val replacedResult = mutableListOf<GasStationDto>()
+        collection.find().into(replacedResult)
+        assertEquals(1, replacedResult.size)
+        assertEquals(gasStation[0].name, replacedResult[0].name)
+    }
+
+    @Test
+    fun `Replace all gas stations with no one given an empty list of gas stations`() {
+        val gasStation = listOf<GasStation>()
+        gasStationPersisterMongo
+            .replace(gasStation)
+
+        val replacedResult = mutableListOf<GasStationDto>()
+        collection.find().into(replacedResult)
+        assertEquals(0, replacedResult.size)
+    }
 }
 
 private fun gasStationDtos(): List<GasStationDto> = listOf(

--- a/app/src/test/kotlin/botlinera/infrastructure/schedulers/GasStationSchedulerShould.kt
+++ b/app/src/test/kotlin/botlinera/infrastructure/schedulers/GasStationSchedulerShould.kt
@@ -1,17 +1,42 @@
 package botlinera.infrastructure.schedulers
 
 import botlinera.application.usecases.UpdateGasStations
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
+import java.lang.Thread.sleep
+import java.util.concurrent.TimeUnit.MINUTES
+import java.util.concurrent.TimeUnit.SECONDS
 
 class GasStationSchedulerShould {
     @Test
-    fun updateGasStationsAtStartup() {
+    fun `execute job at start`() {
         val fakeUpdateGasStations = mockk<UpdateGasStations>(relaxed = true)
 
-        GasStationScheduler().start { fakeUpdateGasStations.execute() }
+        GasStationScheduler.start({ fakeUpdateGasStations.execute() }, 0, 30, MINUTES)
 
         verify(exactly = 1) { fakeUpdateGasStations.execute() }
+    }
+
+    @Test
+    fun `execute job at every execution interval`() {
+        val fakeUpdateGasStations = mockk<UpdateGasStations>(relaxed = true)
+
+        GasStationScheduler.start({ fakeUpdateGasStations.execute() }, 0, 4, SECONDS)
+
+        sleep(6000)
+        verify(exactly = 2) { fakeUpdateGasStations.execute() }
+    }
+
+    @Test
+    fun `do not stop the scheduler if something fails at the job`() {
+        val fakeUpdateGasStations = mockk<UpdateGasStations>(relaxed = true)
+        every { fakeUpdateGasStations.execute() } throws Exception()
+
+        GasStationScheduler.start({ fakeUpdateGasStations.execute() }, 0, 4, SECONDS)
+
+        sleep(6000)
+        verify(exactly = 2) { fakeUpdateGasStations.execute() }
     }
 }


### PR DESCRIPTION
- If an empty list of gas stations is retrieved, we don't call the repository. The repository also do nothing when we call it with an empty list.
- The scheduler handle incoming exceptions and log an error.